### PR TITLE
CB2-4347: Update S3 Events to loop

### DIFF
--- a/src/handler/s3Event.ts
+++ b/src/handler/s3Event.ts
@@ -1,10 +1,27 @@
 /* eslint-disable security/detect-non-literal-fs-filename */
 import * as fs from 'fs';
-import type { S3Event } from 'aws-lambda';
+import type { S3Event, S3EventRecord } from 'aws-lambda';
 import { configureFile } from '../fileConvert/fileConvert';
 import { filePull } from '../filePull/fromS3';
 import { filePush } from '../filePush/filePush';
 import { randomUUID } from 'crypto';
+import logger from '../util/logger';
+
+
+const handleEvent = async (record: S3EventRecord) => {
+  const workingDir = `/tmp/${randomUUID()}/`;
+  try {
+    fs.mkdirSync(workingDir);
+    const evlFileData = await filePull(record);
+    const filepath = await configureFile(workingDir, evlFileData.data, evlFileData.filename);
+    await filePush(filepath);
+  } catch (err) {
+    throw err;
+  } finally {
+    fs.rmSync(workingDir, { recursive: true, force: true });
+  }
+
+};
 
 /**
  * Lambda Handler
@@ -16,15 +33,16 @@ import { randomUUID } from 'crypto';
 export const handler = async (
   event: S3Event,
 ): Promise<Record<string, unknown>> => {
-  const workingDir = `/tmp/${randomUUID()}/`;
-  try {
-    fs.mkdirSync(workingDir);
-    const record = event.Records[0];
-    const evlFileData = await filePull(record);
-    const filepath = await configureFile(workingDir, evlFileData.data, evlFileData.filename);
-    await filePush(filepath);
-  } finally {
-    fs.rmSync(workingDir, { recursive: true, force: true });
+
+  for (const record of event.Records) {
+    try {
+      await handleEvent(record);
+    } catch  (err) {
+      console.error(err);
+      return Promise.resolve({
+        statusCode: 500,
+      });
+    }
   }
 
   return Promise.resolve({

--- a/src/handler/s3Event.ts
+++ b/src/handler/s3Event.ts
@@ -5,8 +5,6 @@ import { configureFile } from '../fileConvert/fileConvert';
 import { filePull } from '../filePull/fromS3';
 import { filePush } from '../filePush/filePush';
 import { randomUUID } from 'crypto';
-import logger from '../util/logger';
-
 
 const handleEvent = async (record: S3EventRecord) => {
   const workingDir = `/tmp/${randomUUID()}/`;

--- a/src/handler/s3Event.ts
+++ b/src/handler/s3Event.ts
@@ -5,6 +5,7 @@ import { configureFile } from '../fileConvert/fileConvert';
 import { filePull } from '../filePull/fromS3';
 import { filePush } from '../filePush/filePush';
 import { randomUUID } from 'crypto';
+import logger from '../util/logger';
 
 const handleEvent = async (record: S3EventRecord) => {
   const workingDir = `/tmp/${randomUUID()}/`;
@@ -36,7 +37,8 @@ export const handler = async (
     try {
       await handleEvent(record);
     } catch  (err) {
-      console.error(err);
+      logger.error(err);
+      logger.error(`The file ${record.s3.object.key} failed somewhere, 500 was returned.`);
       return Promise.resolve({
         statusCode: 500,
       });

--- a/src/handler/s3Event.ts
+++ b/src/handler/s3Event.ts
@@ -14,8 +14,6 @@ const handleEvent = async (record: S3EventRecord) => {
     const evlFileData = await filePull(record);
     const filepath = await configureFile(workingDir, evlFileData.data, evlFileData.filename);
     await filePush(filepath);
-  } catch (err) {
-    throw err;
   } finally {
     fs.rmSync(workingDir, { recursive: true, force: true });
   }

--- a/tests/handler/s3Event.test.ts
+++ b/tests/handler/s3Event.test.ts
@@ -25,6 +25,7 @@ jest.mock('ssh2-sftp-client', () => {
 });
 
 import event from '../resources/s3event.json';
+import eventTwo from '../resources/s3eventTwo.json';
 import type { S3Event } from 'aws-lambda';
 import { GetObjectOutput } from 'aws-sdk/clients/s3';
 import { handler } from '../../src/handler/s3Event';
@@ -48,11 +49,66 @@ describe('Test S3 Event Lambda Function', () => {
       ContentType: 'text/csv',
       Body: Buffer.from('File content'),
     };
-    mockS3.promise.mockResolvedValueOnce(getObjectOutput);
+    mockS3.promise.mockResolvedValue(getObjectOutput);
     const eventMock: S3Event = event as S3Event;
 
     const res: Record<string, unknown> = await handler(eventMock);
 
     expect(res.statusCode).toBe(204);
+  });
+
+  test('should return 204 with multiple s3 events', async () => {
+    jest.spyOn(filePush, 'createConfig').mockImplementation(() => {
+      const config = {
+        host: process.env.SFTP_Host,
+        username: process.env.SFTP_User,
+        retries: 3,
+        password: 'testPassword',
+      };
+      return config;
+    });
+    mockConnect.mockReturnValue(Promise.resolve(true));
+    mockFastPut.mockReturnValue(Promise.resolve('uploaded'));
+    mockEnd.mockReturnValue(Promise.resolve(void 0));
+    const getObjectOutput: GetObjectOutput = {
+      ContentType: 'text/csv',
+      Body: Buffer.from('File content'),
+    };
+    mockS3.promise.mockResolvedValue(getObjectOutput);
+    const eventMock: S3Event = eventTwo as S3Event;
+
+    const res: Record<string, unknown> = await handler(eventMock);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  test('should return 500 with multiple s3 events if one breaks', async () => {
+    jest.spyOn(filePush, 'createConfig').mockImplementation(() => {
+      const config = {
+        host: process.env.SFTP_Host,
+        username: process.env.SFTP_User,
+        retries: 3,
+        password: 'testPassword',
+      };
+      return config;
+    });
+    mockConnect.mockReturnValue(Promise.resolve(true));
+    mockFastPut.mockReturnValue(Promise.resolve('uploaded'));
+    mockEnd.mockReturnValue(Promise.resolve(void 0));
+    const getObjectOutput: GetObjectOutput = {
+      ContentType: 'text/csv',
+      Body: Buffer.from('File content'),
+    };
+    const getObjectOutputBroken: GetObjectOutput = {
+      ContentType: 'text',
+      Body: Buffer.from('File content'),
+    };
+    mockS3.promise.mockResolvedValueOnce(getObjectOutput);
+    mockS3.promise.mockResolvedValueOnce(getObjectOutputBroken);
+    const eventMock: S3Event = eventTwo as S3Event;
+
+    const res: Record<string, unknown> = await handler(eventMock);
+
+    expect(res.statusCode).toBe(500);
   });
 });

--- a/tests/resources/s3event.json
+++ b/tests/resources/s3event.json
@@ -33,40 +33,6 @@
           "sequencer": "0062A84E310AE821DE"
         }
       }
-    },
-    {
-      "eventVersion": "2.1",
-      "eventSource": "aws:s3",
-      "awsRegion": "eu-west-1",
-      "eventTime": "2022-06-11T15:38:51.087Z",
-      "eventName": "ObjectCreated:Put",
-      "userIdentity": {
-        "principalId": "A3P1HWYVAMJVPS"
-      },
-      "requestParameters": {
-        "sourceIPAddress": "51.199.204.51"
-      },
-      "responseElements": {
-        "x-amz-request-id": "0F2179V9NC3972GE",
-        "x-amz-id-2": "0sHV2E/eqOllDAbcj3FyC3ohfNqQEsseo7u6QjIvNZQdiasRo/KSXRy++faoQ7VQgth0rf+ghREyjl00stldaJmjryJJ6hQJ"
-      },
-      "s3": {
-        "s3SchemaVersion": "1.0",
-        "configurationId": "7ddea92e-cee0-431e-a05b-d2d00b8650ce",
-        "bucket": {
-          "name": "s3-lambda-testing-7654",
-          "ownerIdentity": {
-            "principalId": "A3P1HWYVAMJVPS"
-          },
-          "arn": "arn:aws:s3:::s3-lambda-testing-7654"
-        },
-        "object": {
-          "key": "EmmaAfricaPattern.png",
-          "size": 4843914,
-          "eTag": "8985c094590073808e05ab2576afe3a4",
-          "sequencer": "0062A4B70B002FF40A"
-        }
-      }
     }
   ]
 }

--- a/tests/resources/s3eventTwo.json
+++ b/tests/resources/s3eventTwo.json
@@ -1,0 +1,73 @@
+{
+    "Records": [
+      {
+        "eventVersion": "2.1",
+        "eventSource": "aws:s3",
+        "awsRegion": "eu-west-1",
+        "eventTime": "2022-06-14T09:00:33.057Z",
+        "eventName": "ObjectCreated:Put",
+        "userIdentity": {
+          "principalId": "A3P1HWYVAMJVPS"
+        },
+        "requestParameters": {
+          "sourceIPAddress": "154.14.88.250"
+        },
+        "responseElements": {
+          "x-amz-request-id": "85Z8PWW9S14ZMK84",
+          "x-amz-id-2": "1scBcvA4LhGXb00tEqxFG4+U2rDj2MGRfZBI5sE/29QvWEjdl53ZmrIedC1+hZzEbUCOwLqHF1b85gpvglqII1iBdyRf7pso"
+        },
+        "s3": {
+          "s3SchemaVersion": "1.0",
+          "configurationId": "7ddea92e-cee0-431e-a05b-d2d00b8650ce",
+          "bucket": {
+            "name": "evl-bucket",
+            "ownerIdentity": {
+              "principalId": "A3P1HWYVAMJVPS"
+            },
+            "arn": "arn:aws:s3:::evl-bucket"
+          },
+          "object": {
+            "key": "EVL_GVT_20220621.csv",
+            "size": 60,
+            "eTag": "c4c7b60167b533a5eae07b5ce38d7368",
+            "sequencer": "0062A84E310AE821DE"
+          }
+        }
+      },
+      {
+        "eventVersion": "2.1",
+        "eventSource": "aws:s3",
+        "awsRegion": "eu-west-1",
+        "eventTime": "2022-06-11T15:38:51.087Z",
+        "eventName": "ObjectCreated:Put",
+        "userIdentity": {
+          "principalId": "A3P1HWYVAMJVPS"
+        },
+        "requestParameters": {
+          "sourceIPAddress": "51.199.204.51"
+        },
+        "responseElements": {
+          "x-amz-request-id": "0F2179V9NC3972GE",
+          "x-amz-id-2": "0sHV2E/eqOllDAbcj3FyC3ohfNqQEsseo7u6QjIvNZQdiasRo/KSXRy++faoQ7VQgth0rf+ghREyjl00stldaJmjryJJ6hQJ"
+        },
+        "s3": {
+          "s3SchemaVersion": "1.0",
+          "configurationId": "7ddea92e-cee0-431e-a05b-d2d00b8650ce",
+          "bucket": {
+            "name": "s3-lambda-testing-7654",
+            "ownerIdentity": {
+              "principalId": "A3P1HWYVAMJVPS"
+            },
+            "arn": "arn:aws:s3:::s3-lambda-testing-7654"
+          },
+          "object": {
+            "key": "EVL_GVT_20220622.csv",
+            "size": 4843914,
+            "eTag": "8985c094590073808e05ab2576afe3a4",
+            "sequencer": "0062A4B70B002FF40A"
+          }
+        }
+      }
+    ]
+  }
+  


### PR DESCRIPTION
## Description

The s3 events could have multiple records attached, we have now added a loop to manage this.

Related issue: [4347](https://dvsa.atlassian.net/browse/CB2-4347)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works