### PR TITLE
fix(cb2-6839): remove inner zip of CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18711,7 +18711,7 @@
         "file-type": "^16.5.3",
         "filenamify": "^4.3.0",
         "get-stream": "^6.0.1",
-        "got": "^11.8.3",
+        "got": "^11.8.5",
         "inquirer": "^8.2.4",
         "js-yaml": "^4.1.0",
         "jwt-decode": "^3.1.2",
@@ -25755,7 +25755,7 @@
       "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
-        "got": "^9.6.0",
+        "got": "^11.8.5",
         "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
         "semver": "^6.2.0"

--- a/src/fileConvert/fileConvert.ts
+++ b/src/fileConvert/fileConvert.ts
@@ -50,7 +50,7 @@ export const configureEvlFile = async (
 
     const csvData = data.join('\n');
     fs.writeFileSync(workingDir + csvFilename, csvData);
-    logger.info('Written zipped csv file');
+    logger.info('Written csv file');
 
     const md5sum = md5(csvData);
     fs.writeFileSync(workingDir + textFilename, md5sum);

--- a/src/fileConvert/fileConvert.ts
+++ b/src/fileConvert/fileConvert.ts
@@ -2,7 +2,6 @@
 import md5 from 'md5';
 import tar from 'tar';
 import * as fs from 'fs';
-import * as zlib from 'zlib';
 import logger from '../util/logger';
 
 export const configureEvlFile = async (
@@ -27,7 +26,7 @@ export const configureEvlFile = async (
   const textFilenamePrefix = 'crc32_';
   const archiveNamePrefix = 'EVL_GVT_';
   const dateFromFilename = filename.split('_')[2].split('.')[0];
-  const zipCsvFilename = archiveNamePrefix + dateFromFilename + '.csv.gz';
+  const csvFilename = archiveNamePrefix + dateFromFilename + '.csv';
   const textFilename = textFilenamePrefix + dateFromFilename + '.txt';
   const archiveName =
     workingDir + archiveNamePrefix + dateFromFilename + '.tar.gz';
@@ -49,17 +48,17 @@ export const configureEvlFile = async (
     data.splice(data.length, 0, trailerLine);
     logger.info('Spliced data into the csv file');
 
-    const zipData = zlib.gzipSync(data.join('\n'));
-    fs.writeFileSync(workingDir + zipCsvFilename, zipData);
+    const csvData = data.join('\n');
+    fs.writeFileSync(workingDir + csvFilename, csvData);
     logger.info('Written zipped csv file');
 
-    const md5sum = md5(zipData);
+    const md5sum = md5(csvData);
     fs.writeFileSync(workingDir + textFilename, md5sum);
     logger.info('Written txt checksum file');
 
     await tar.c({ gzip: true, file: archiveName, cwd: workingDir }, [
       textFilename,
-      zipCsvFilename,
+      csvFilename,
     ]);
     logger.info('Written tar file');
     return archiveName;

--- a/tests/fileConvert/fileConvert.test.ts
+++ b/tests/fileConvert/fileConvert.test.ts
@@ -11,14 +11,14 @@ describe('test the file config', () => {
     .split('_')[2]
     .split('.')[0];
   const txtFilename = 'crc32_' + dateFromFilename + '.txt';
-  const zipCsvFilename = 'EVL_GVT_' + dateFromFilename + '.csv.gz';
+  const csvFilename = 'EVL_GVT_' + dateFromFilename + '.csv';
   const finalFilename = 'EVL_GVT_' + dateFromFilename + '.tar.gz';
 
   let buffer: Buffer;
 
   afterEach(() => {
     fs.unlinkSync(finalFilename);
-    fs.unlinkSync(zipCsvFilename);
+    fs.unlinkSync(csvFilename);
     fs.unlinkSync(txtFilename);
   });
 
@@ -35,7 +35,7 @@ describe('test the file config', () => {
   test('expect csv filename to be correct', async () => {
     await configureEvlFile('', buffer, 'EVL_GVT_20220621.csv');
     const fileList = fs.readdirSync('./');
-    expect(fileList).toContain(zipCsvFilename);
+    expect(fileList).toContain(csvFilename);
   });
 
   test('expect txt filename to be correct', async () => {
@@ -46,8 +46,7 @@ describe('test the file config', () => {
 
   test('expect csv to include the header and footer', async () => {
     await configureEvlFile('', buffer, 'EVL_GVT_20220621.csv');
-    const zipCsvFile = fs.readFileSync(zipCsvFilename);
-    const csvFile = zlib.gunzipSync(zipCsvFile);
+    const csvFile = fs.readFileSync(csvFilename);
     const csvData = csvFile.toString();
     expect(csvData).toContain('HEADER LINE: EVL GVT TRANSFER FILE');
     expect(csvData).toContain('TRAILER LINE: 2 RECORDS.');
@@ -55,7 +54,7 @@ describe('test the file config', () => {
 
   test('expect hash to match', async () => {
     await configureEvlFile('', buffer, 'EVL_GVT_20220621.csv');
-    const csvFile = fs.readFileSync(zipCsvFilename);
+    const csvFile = fs.readFileSync(csvFilename);
     const textFile = fs.readFileSync(txtFilename);
     const hash = md5(csvFile);
     expect(textFile.toString()).toBe(hash);

--- a/tests/fileConvert/fileConvert.test.ts
+++ b/tests/fileConvert/fileConvert.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable security/detect-non-literal-fs-filename */
 import { configureEvlFile } from '../../src/fileConvert/fileConvert';
 import * as fs from 'fs';
-import * as zlib from 'zlib';
 import md5 from 'md5';
 
 describe('test the file config', () => {


### PR DESCRIPTION
## Description

It turns out that we do not need to zip the internal CSV file as originally thought, this change removes that and updates the logs to reflect it.

Related issue: [https://dvsa.atlassian.net/browse/CB2-6839](6839)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
